### PR TITLE
[FEAT] Tornament base page added

### DIFF
--- a/frontend/public/style/card.css
+++ b/frontend/public/style/card.css
@@ -26,27 +26,32 @@
 	font-size: 2rem;
 }
 
+.tp-sl-card-button-text {
+	font-size: 1rem;
+}
+
 .tp-sl-btn-primary {
-  animation: flashText 1.5s ease-out alternate infinite;
+	animation: none
 }
 
 .tp-sl-btn-primary:hover {
 	animation: none;
 }
 
-.tp-sl-card-row:hover .tp-sl-btn-parent:not(:hover) > .btn {
+.tp-sl-card-row:hover .tp-sl-btn-parent:not(:hover)>.btn {
 	animation: none;
 	opacity: 0.5;
 }
 
-@keyframes flash{
-  to {
-    opacity: 1;
-  }
+
+@keyframes flash {
+	to {
+		opacity: 1;
+	}
 }
 
 @keyframes flashText {
-  to {
-    opacity: 0.15;
-  }
+	to {
+		opacity: 0.15;
+	}
 }

--- a/frontend/src/pages/home.js
+++ b/frontend/src/pages/home.js
@@ -1,19 +1,15 @@
 function Home($container) {
-    this.$container = $container;
+	this.$container = $container;
 
-    this.setState = () => {
-        this.render();
-    };
+	this.setState = () => {
+		this.render();
+	};
 
-    this.render = () => {
-        const url = `https://api.intra.42.fr/oauth/authorize?client_id=${process.env.CLIENT_ID}&redirect_uri=https://${process.env.BASE_IP}:443/api/v1/login/42/callback/&response_type=code&state=311b7a86-a33a-4c61-9f5a-494ff36a272d`;
-
-        this.$container.innerHTML = `
+	this.render = () => {
+		this.$container.innerHTML = `
       <div class="content default-container">
         <div class="sized-box"></div>
         <div class = "default-container home-top-container">
-          <button type="button" class="btn btn-primary" id="fetchUserDataBtn">Primary</button>
-          <a href=${url} class="btn btn-primary">PONG GAME</a>
         </div>
         <div class="sized-box"></div>
         <div class="sized-box"></div>
@@ -23,9 +19,9 @@ function Home($container) {
         </div>
       </div>
 	  `;
-    };
+	};
 
-    this.render();
+	this.render();
 }
 
 export default Home;

--- a/frontend/src/pages/selectMode.js
+++ b/frontend/src/pages/selectMode.js
@@ -98,7 +98,7 @@ function SelectMode({ initialState }) {
 				event.preventDefault();
 				const multiTextElement = document.querySelector(".tp-sl-multi-btn .tp-sl-card-text");
 				multiTextElement.textContent = "Waiting for other players...";
-				initSocket = new WebSocket("ws://127.0.0.1:5500/ws/general_game/wait/");
+				initSocket = new WebSocket("wss://127.0.0.1:443/ws/general_game/wait/");
 				initSocket.addEventListener('message', idSocketConnect);
 			});
 		}

--- a/frontend/src/pages/selectMode.js
+++ b/frontend/src/pages/selectMode.js
@@ -1,24 +1,23 @@
 import { $ } from "../utils/querySelector.js";
-import { BASE_URL } from "../utils/routeInfo.js";
 import { navigate } from "../utils/navigate.js";
 import { getCurrentLanguage } from "../utils/languageUtils.js";
 import locales from "../utils/locales/locales.js";
 
 function SelectMode({ initialState }) {
-    this.state = initialState;
-    this.$element = document.createElement("div");
-    this.$element.className = "content default-container tp-sl-card-content";
+	this.state = initialState;
+	this.$element = document.createElement("div");
+	this.$element.className = "content default-container tp-sl-card-content";
 
-    this.setState = (content) => {
-        this.state = content;
-        this.render();
-    };
+	this.setState = (content) => {
+		this.state = content;
+		this.render();
+	};
 
-    this.render = () => {
-      const language = getCurrentLanguage();
-      const locale = locales[language] || locales.en;
+	this.render = () => {
+		const language = getCurrentLanguage();
+		const locale = locales[language] || locales.en;
 
-        this.$element.innerHTML = `
+		this.$element.innerHTML = `
       <div class="tp-sl-card-content-child">
         <div class="tp-sl-title-container default-container text-center tp-color-secondary">
           <h1>${locale.selectMode.mainText}</h1>
@@ -26,7 +25,7 @@ function SelectMode({ initialState }) {
         <div class="tp-sl-card-container default-container text-center">
           <form class="tp-sl-card-row tp-sl-card-row-height row g-2">
             <div class="tp-sl-btn-parent col">
-                <button type="submit" class="btn tp-btn-primary tp-sl-btn-primary tp-sl-single-btn card h-100" value="/game"> 
+                <button type="submit" class="tp-btn-primary tp-sl-btn-primary tp-sl-single-btn card h-100" value="/game"> 
                   <div class="card-body row">
                     <div></div>
                     <h5 class="tp-sl-card-title default-container">${locale.selectMode.singleMode}</h5>
@@ -43,52 +42,81 @@ function SelectMode({ initialState }) {
                   </div>
                 </button>
             </div>
+						<div class="tp-sl-btn-parent col">
+                <button type="submit" class="btn tp-btn-primary tp-sl-btn-primary tp-sl-tornament-btn card h-100" value="/tornament">
+                  <div class="card-body row">
+                    <div></div>
+                    <h5 class="tp-sl-card-title default-container">${locale.selectMode.tornamentMode}</h5>
+                    <p class="tp-sl-card-text default-container">${locale.selectMode.tornamentModeDesc}</p>
+                  </div>
+                </button>
+            </div>
           </form>
         </div>
       </div>
 		`;
-    };
+	};
 
-    this.init = () => {
-        let parent = $("#app");
-        const child = $(".content");
-        if (child) {
-            parent.removeChild(child);
-            parent.appendChild(this.$element);
-        }
-        let body = $("body");
-        const canvas = $("canvas");
-        if (canvas) {
-            body.removeChild(canvas);
-        }
-        this.render();
+	this.init = () => {
+		let parent = $("#app");
+		const child = $(".content");
+		if (child) {
+			parent.removeChild(child);
+			parent.appendChild(this.$element);
+		}
+		let body = $("body");
+		const canvas = $("canvas");
+		if (canvas) {
+			body.removeChild(canvas);
+		}
+		this.render();
 
-        const singleBtn = $(".tp-sl-single-btn");
-        const multiBtn = $(".tp-sl-multi-btn");
+		const singleBtn = $(".tp-sl-single-btn");
+		const multiBtn = $(".tp-sl-multi-btn");
+		const tornamentBtn = $(".tp-sl-tornament-btn");
+		let targetURL;
+		if (singleBtn) {
+			singleBtn.addEventListener("click", function (event) {
+				event.preventDefault();
+				targetURL = `https://${process.env.BASE_IP}${this.value}`;
+				console.log("targetURL", targetURL);
+				navigate(targetURL);
+			});
+		}
+		if (tornamentBtn) {
+			tornamentBtn.addEventListener("click", function (event) {
+				event.preventDefault();
+				targetURL = `https://${process.env.BASE_IP}${this.value}`;
+				console.log("targetURL", targetURL);
+				navigate(targetURL);
+			});
+		}
+		let gameIdObject, gameIdValue, gameInfo, initSocket;
 
-        if (singleBtn) {
-            singleBtn.addEventListener("click", function (event) {
-                event.preventDefault();
-                const targetURL = BASE_URL + this.value;
-                console.log("targetURL", targetURL);
-                navigate(targetURL);
-            });
-        }
+		if (multiBtn) {
+			multiBtn.addEventListener("click", function (event) {
+				event.preventDefault();
+				const multiTextElement = document.querySelector(".tp-sl-multi-btn .tp-sl-card-text");
+				multiTextElement.textContent = "Waiting for other players...";
+				initSocket = new WebSocket("ws://127.0.0.1:8000/ws/general_game/wait/");
+				initSocket.addEventListener('message', idSocketConnect);
+			});
+		}
 
-        if (multiBtn) {
-            multiBtn.addEventListener("click", function (event) {
-                event.preventDefault();
-                const targetURL = BASE_URL + this.value;
-                navigate(targetURL);
-              });
-        }
-    };
+		const idSocketConnect = (event) => {
+			console.log('Message from server ', event.data);
+			initSocket.close();
+			gameInfo = event.data;
+			gameIdObject = JSON.parse(event.data);
+			gameIdValue = gameIdObject.game_id;
+			// 현재 연결된 소켓을 세션 스토리지에 저장합니다.
+			sessionStorage.setItem('gameIdValue', gameIdValue);
+			targetURL = `https://${process.env.BASE_IP}general_game/${gameIdValue}`;
+			navigate(targetURL);
+		}
+	};
 
-    window.addEventListener("languageChange", function() {
-      this.render();
-    }.bind(this));
-
-    this.init();
+	this.init();
 }
 
 export default SelectMode;

--- a/frontend/src/pages/selectMode.js
+++ b/frontend/src/pages/selectMode.js
@@ -98,7 +98,7 @@ function SelectMode({ initialState }) {
 				event.preventDefault();
 				const multiTextElement = document.querySelector(".tp-sl-multi-btn .tp-sl-card-text");
 				multiTextElement.textContent = "Waiting for other players...";
-				initSocket = new WebSocket("ws://127.0.0.1:8000/ws/general_game/wait/");
+				initSocket = new WebSocket("ws://127.0.0.1:5500/ws/general_game/wait/");
 				initSocket.addEventListener('message', idSocketConnect);
 			});
 		}

--- a/frontend/src/pages/tornament.js
+++ b/frontend/src/pages/tornament.js
@@ -1,0 +1,221 @@
+import { $ } from "../utils/querySelector.js";
+import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
+import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
+import { FontLoader } from 'three/addons/loaders/FontLoader.js';
+import * as THREE from "three";
+import { getCurrentLanguage } from "../utils/languageUtils.js";
+import locales from "../utils/locales/locales.js";
+
+function Tornament({ $app, initialState }) {
+	this.state = initialState;
+	this.$element = document.createElement("div");
+	this.$element.className = "content";
+	this.waitSocket = null;
+	let tournamentName, playerNum, intraId;
+
+	//초기 토너먼트 테이블 렌더
+	this.render = () => {
+		const language = getCurrentLanguage();
+		const locale = locales[language] || locales.en;
+		this.$element.innerHTML = `
+        <div class="content default-container">
+            <div class="container">
+                <div class="mb-3 mt-3">
+                    <div class="h1 text-left tp-color-secondary">${locale.tornament.mainText}</div>
+                    <div class="h4 text-left tp-color-secondary">${locale.tornament.mainTextDesc}</div>
+                </div>
+                <div class="row justify-content-center default-container">
+                    <div class="tp-sl-card-row">
+                        <div class="table-responsive" style="opacity:100%">
+                            <table class="table table-dark table-responsive-md" style="border-spacing: 0 10px;">
+                                <thead>
+                                    <tr class="text-center align-middle">
+                                        <th class="tp-bgc-secondary">No. </th>
+                                        <th class="tp-bgc-secondary">${locale.tornament.list}</th>
+                                        <th class="tp-bgc-secondary"></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                </tbody>
+                            </table>
+														<div class="tp-sl-btn-parent col">
+          					          <button id="createTournamentBtn" class="tp-btn-primary"> 
+              			        	  <div class="card-body row">
+                 			    	    <p class="tp-sl-card-button-text default-container">${locale.tornament.createBtn}</p>
+                  			    	  </div>
+                  					  </button>
+                              <button id="refreshBtn" class="tp-btn-primary ">${locale.tornament.refresh}
+															</button>
+              						  </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+		// Create New Tournament 버튼 클릭 이벤트 핸들러 등록
+		const createTournamentBtn = this.$element.querySelector("#createTournamentBtn");
+		createTournamentBtn.addEventListener("click", () => {
+			tournamentName = prompt("Enter the name of the new tournament:");
+			const message = {
+				"message_type": "create",
+				"tournament_name": tournamentName
+			};
+			this.waitSocket.send(JSON.stringify(message));
+		});
+		// Refresh 버튼 클릭 이벤트 핸들러 등록
+		const refreshBtn = this.$element.querySelector("#refreshBtn");
+		refreshBtn.addEventListener("click", () => {
+			this.render();
+		});
+
+		this.getTornamentList();
+	};
+
+	// 서버로 wait 소켓 연결하고 토너먼트 리스트 불러옴
+	this.getTornamentList = async () => {
+		try {
+			await this.connectWebSocket("wait");
+			this.waitSocket.addEventListener('message', (event) => {
+				const data = JSON.parse(event.data);
+				console.log("Received data:", data);
+				// 플레이어 정보 초기화
+				playerNum = false;
+				intraId = false;
+				if (data.game_list) {
+					// 토너먼트 리스트를 받은 경우
+					this.fillTable(data.game_list);
+				} else if (data.message_type === "create") {
+					if (data.result === "success") {
+						// 방 생성 성공 시 처리
+						this.renderWaiting();
+					} else if (data.result === "fail") {
+						// 방 생성 실패 시 처리
+						console.error("Failed to create tournament: duplicated");
+						alert("Same name tornament already exist.");
+						this.render();
+					}
+				}
+			});
+		} catch (error) {
+			console.error("Error socket connect:", error);
+		}
+	};
+
+	//받은 데이터로 리스팅
+	this.fillTable = (gameList) => {
+		const tableBody = this.$element.querySelector("tbody");
+		if (!tableBody) {
+			console.error("Table body element not found.");
+			return;
+		}
+
+		if (Array.isArray(gameList) && gameList.length > 0) {
+			const tableRows = gameList.map((game, index) => `
+			<tr>
+          <td class="text-center align-middle col-1">${index + 1}</td>
+          <td class="text-center align-middle col-2">
+              <span class="tournamentNameText" style="cursor: pointer; color: #E5CC5E;">${game.tournament_name}</span>
+          </td>
+          <td class="text-center align-middle col-1">${game.wait_num}/4</td>
+      </tr>
+        `).join("");
+
+			tableBody.innerHTML = tableRows;
+			// 토너먼트 이름 버튼에 클릭 이벤트 핸들러 등록
+			const tournamentNameTexts = tableBody.querySelectorAll(".tournamentNameText");
+			tournamentNameTexts.forEach((text) => {
+				text.addEventListener("click", () => {
+					// 선택된 토너먼트 이름을 전역 변수 tournamentName에 할당
+					tournamentName = text.textContent;
+					console.log(tournamentName);
+					// 선택된 토너먼트로 renderWaiting 호출하여 소켓 연결 시도
+					this.renderWaiting();
+				});
+			});
+		} else {
+			tableBody.innerHTML = "<tr><td colspan='3' class='text-left'>No games available</td></tr>";
+		}
+	};
+
+	// 새로운 토너먼트 생성시 참가 대기소켓 연결
+	this.renderWaiting = async () => {
+		try {
+			await this.connectWebSocket(tournamentName); // 기존의 메세지 리스너 같이 사라짐
+			this.waitSocket.addEventListener('message', (event) => {
+				const data = JSON.parse(event.data);
+				if (intraId == false || intraId == data.intra_id) {
+					intraId = data.intra_id;
+					playerNum = data.number;
+				}
+
+				console.log("I am : " + playerNum + " " + intraId);
+				this.waitSocket.send(event.data);
+
+
+				console.log("Received 대기중 data:", data);
+				this.$element.innerHTML = `
+        <div class='text-center h1 text-left tp-color-secondary'>Waiting other players...</div>
+        <div class='text-center h1 text-left tp-color-secondary'>${data.total} / 4</div>
+        <div class="text-center">
+            <button id="goBackToListBtn" class="btn tp-btn-primary">Go back to list</button>
+        </div>
+    `;
+				// "Go back to list" 버튼 클릭 이벤트 핸들러 등록
+				const goBackToListBtn = this.$element.querySelector("#goBackToListBtn");
+				goBackToListBtn.addEventListener("click", this.goBackToList);
+			});
+		} catch (error) {
+			console.error("뭔가;; 잘못됨:", error);
+		}
+	};
+
+	this.goBackToList = () => {
+		// 소켓 연결을 끊음
+		if (this.waitSocket) {
+			this.waitSocket.close();
+			this.waitSocket = null;
+		}
+		// 토너먼트 리스트를 다시 요청
+		this.render();
+	};
+
+	//소켓 연결시 사용
+	this.connectWebSocket = async (url) => {
+		return new Promise((resolve, reject) => {
+			console.log("소켓연결: wss://127.0.0.1:443/ws/tournament_game/" + url);
+			this.waitSocket = new WebSocket(`wss://127.0.0.1/ws/tournament_game/${url}/`);
+
+			this.waitSocket.onopen = () => {
+				console.log('WebSocket connected');
+				resolve(this.waitSocket);
+			};
+
+			this.waitSocket.onerror = (error) => {
+				reject(error);
+			};
+		});
+	};
+
+
+
+	// 기본적인 SPA 페이지 로드동작
+	this.init = () => {
+		let parent = $("#app");
+		const child = $(".content");
+		if (child) {
+			parent.removeChild(child);
+			parent.appendChild(this.$element);
+		}
+		let body = $("body");
+		const canvas = $("canvas");
+		if (canvas) {
+			body.removeChild(canvas);
+		}
+		this.render();
+	};
+
+	this.init();
+}
+
+export default Tornament;

--- a/frontend/src/utils/eventListener.js
+++ b/frontend/src/utils/eventListener.js
@@ -1,52 +1,52 @@
 import { navigate } from "./navigate.js";
-import { BASE_URL } from "./routeInfo.js";
 import { fetchUser, fetchLogoutRequest } from "./fetches.js";
 // import { renderPage } from "../component/navBar.js";
 // import { changeLanguage, getCurrentLanguage, setLanguageCookie } from "./languageUtils.js";
 
 export function addLoginEventListener(loginContainer) {
-    fetchUser().then((myInfo) => {
-        if (myInfo !== false && myInfo.detail === undefined) {
-            closeLoginModal(loginContainer);
-        }
-    });
+	fetchUser().then((myInfo) => {
+		if (myInfo !== false && myInfo.detail === undefined) {
+			closeLoginModal(loginContainer);
+		}
+	});
 
-    const handleLoginResponse = (response) => {
-        if (response.ok) {
-            document.cookie = response.headers.get("Set-Cookie");
-            console.log("response:", response);
-            closeLoginModal(loginContainer);
-        } else {
-            console.error("Login failed");
-        }
-    };
+	const handleLoginResponse = (response) => {
+		if (response.ok) {
+			document.cookie = response.headers.get("Set-Cookie");
+			console.log("response:", response);
+			closeLoginModal(loginContainer);
+		} else {
+			console.error("Login failed");
+		}
+	};
 
-    const closeLoginModal = (loginContainer) => {
-        loginContainer.style.display = "none";
-    };
+	const closeLoginModal = (loginContainer) => {
+		loginContainer.style.display = "none";
+	};
 
-    const closeButton = loginContainer.querySelector("#close-btn");
-    closeButton.addEventListener("click", () =>
-        closeLoginModal(loginContainer)
-    );
+	const closeButton = loginContainer.querySelector("#close-btn");
+	closeButton.addEventListener("click", () =>
+		closeLoginModal(loginContainer)
+	);
 }
 
 export function addNavBarClickListener(navBarContainer) {
-    navBarContainer.addEventListener("click", (e) => {
-        const target = e.target.closest("a");
-        if (!(target instanceof HTMLAnchorElement)) return;
+	navBarContainer.addEventListener("click", (e) => {
+		const target = e.target.closest("a");
+		if (!(target instanceof HTMLAnchorElement)) return;
 
-        e.preventDefault();
-        const targetURL = target.href.replace(BASE_URL, "");
-        navigate(targetURL);
-    });
+		e.preventDefault();
+		const targetURL = target.href.replace(`https://${process.env.BASE_IP}`, "");
+		// console.log("\n\n\n\n targetUrl : " + targetURL);
+		navigate(targetURL);
+	});
 
-    const logoutBtn = navBarContainer.querySelector("#logoutBtn");
-    if (logoutBtn) {
-        logoutBtn.addEventListener("click", (event) => {
-            event.preventDefault();
-            fetchLogoutRequest();
-        });
-    }
+	const logoutBtn = navBarContainer.querySelector("#logoutBtn");
+	if (logoutBtn) {
+		logoutBtn.addEventListener("click", (event) => {
+			event.preventDefault();
+			fetchLogoutRequest();
+		});
+	}
 }
 

--- a/frontend/src/utils/locales/en.js
+++ b/frontend/src/utils/locales/en.js
@@ -1,71 +1,80 @@
 const enLocale = {
-  navBar: {
-    brand: "TAIL PASSENGER TEST",
-    pongGame: "PONG GAME",
-    rank: "RANK",
-    records: "RECORDS",
-    profile: "PROFILE",
-    settings: "Settings",
-    logout: "Logout",
-    language: "Language",
-    english: "English",
-    korean: "한국어",
-    japanese: "日本語"
-  },
-  selectMode: {
-    mainText: "Select game mode",
-    singleMode: "Single mode",
-    singleModeDesc: "Single mode against computer",
-    multiMode: "Multi mode",
-    multiModeDesc: "Multi mode against other users"
-  },
-  rank: {
-    mainText: "Top Player",
-    subText: "Thank you for playing",
-    thRank: "Rank",
-    thUserProfile: "Profile",
-    thUserIntraId: "Intra ID",
-    thUserName: "User Name",
-    thWins: "Wins",
-    thLoses: "Loses",
-    thRankPoint: "Rank Point",
-    thFriendRequestBtn: "Friend Request",
-    tootipRequest: "Request"
-  },
-  records: {
-    mainText: "Records",
-  },
-  profileTab: {
-    myInfoTab: "MY",
-    friendListTab: "FRIEND",
-  },
-  friendList: {
-    nofriends: "You have no friends",
-    friendsNumber: "NO",
-    friendsProfile: "PROFILE",
-    friendsNickname: "NICKNAME",
-    friendsConnection: "CONNECTION",
-    friendsRequest: "FRIEND REQUEST",
-    tooltipAccept: "Accept",
-    tooltipRefuse: "Refuse"
-  },
-  myInfo: {
-    myNickname: "NICKNAME",
-    myRecord: "RECORD",
-    myIntraId: "INTRA ID",
-    myHouse: "HOUSE",
-    modifyButton: "MODIFY",
-    win: "WIN",
-    lose: "LOSE",
-    modifyMyInfoTitle: "Modify My Infomation",
-    modifyMyInfoImageButton: "UPLOAD"
-  },
-  house: {
-    griffindor: "Gryffindor",
-    hufflepuff: "Hufflepuff",
-    ravenclaw: "Ravenclaw",
-    slytherin: "Slytherin"
-  }
+	navBar: {
+		brand: "TAIL PASSENGER TEST",
+		pongGame: "PONG GAME",
+		rank: "RANK",
+		records: "RECORDS",
+		profile: "PROFILE",
+		settings: "Settings",
+		logout: "Logout",
+		language: "Language",
+		english: "English",
+		korean: "한국어",
+		japanese: "日本語"
+	},
+	selectMode: {
+		mainText: "Select game mode",
+		singleMode: "Single mode",
+		singleModeDesc: "Single mode against computer",
+		multiMode: "Multi mode",
+		multiModeDesc: "Multi mode against other users",
+		tornamentMode: "Tornament mode",
+		tornamentModeDesc: "Tornament mode with 4 users"
+	},
+	tornament: {
+		mainText: "Tournament List",
+		mainTextDesc: "You can create or join a tournament.",
+		list: "Tournament Name",
+		createBtn: "Create New Tournament",
+		refresh: "Refresh"
+	},
+	rank: {
+		mainText: "Top Player",
+		subText: "Thank you for playing",
+		thRank: "Rank",
+		thUserProfile: "Profile",
+		thUserIntraId: "Intra ID",
+		thUserName: "User Name",
+		thWins: "Wins",
+		thLoses: "Loses",
+		thRankPoint: "Rank Point",
+		thFriendRequestBtn: "Friend Request",
+		tootipRequest: "Request"
+	},
+	records: {
+		mainText: "Records",
+	},
+	profileTab: {
+		myInfoTab: "MY",
+		friendListTab: "FRIEND",
+	},
+	friendList: {
+		nofriends: "You have no friends",
+		friendsNumber: "NO",
+		friendsProfile: "PROFILE",
+		friendsNickname: "NICKNAME",
+		friendsConnection: "CONNECTION",
+		friendsRequest: "FRIEND REQUEST",
+		tooltipAccept: "Accept",
+		tooltipRefuse: "Refuse"
+	},
+	myInfo: {
+		myNickname: "NICKNAME",
+		myRecord: "RECORD",
+		myIntraId: "INTRA ID",
+		myHouse: "HOUSE",
+		modifyButton: "MODIFY",
+		win: "WIN",
+		lose: "LOSE",
+		modifyMyInfoTitle: "Modify My Infomation",
+		modifyMyInfoImageButton: "UPLOAD"
+	},
+	house: {
+		griffindor: "Gryffindor",
+		hufflepuff: "Hufflepuff",
+		ravenclaw: "Ravenclaw",
+		slytherin: "Slytherin"
+	}
 };
 
 export default enLocale;

--- a/frontend/src/utils/locales/ja.js
+++ b/frontend/src/utils/locales/ja.js
@@ -1,71 +1,80 @@
 const jaLocale = {
-  navBar: {
-    brand: "テイル パッセンジャー",
-    pongGame: "ポンゲーム",
-    rank: "ランク",
-    records: "記録",
-    profile: "プロフィール",
-    settings: "設定",
-    logout: "ログアウト",
-    language: "言語",
-    english: "英語",
-    korean: "韓国語",
-    japanese: "日本語"
-  },
-  selectMode: {
-    mainText: "ゲームモードを選択",
-    singleMode: "シングルモード",
-    singleModeDesc: "コンピューターと対戦するシングルモード",
-    multiMode: "マルチモード",
-    multiModeDesc: "他のユーザーと対戦するマルチモード"
-  },
-  rank: {
-    mainText: "トッププレイヤー",
-    subText: "プレイしていただきありがとうございます",
-    thRank: "ランク",
-    thUserProfile: "フロフィルイメージ",
-    thUserIntraId: "イントラアイディー",
-    thUserName: "ユーザー名",
-    thWins: "勝利",
-    thLoses: "敗北",
-    thRankPoint: "ランクポイント",
-    thFriendRequestBtn: "フレンド申請",
-    tootipRequest: "申請"
-  },
-  records: {
-    mainText: "レコード",
-  },
-  profileTab: {
-    myInfoTab: "マイインフォ",
-    friendListTab: "フレンドリスト",
-  },
-  friendList: {
-    nofriends: "フレンドがいません",
-    friendsNumber: "ナンバー",
-    friendsProfile: "フロフィルイメージ",
-    friendsNickname: "ニックネーム",
-    friendsConnection: "コネクション",
-    friendsRequest: "フレンド申請",
-    tooltipAccept: "承認",
-    tooltipRefuse: "拒否"
-  },
-  myInfo: {
-    myNickname: "ニックネーム",
-    myRecord: "レコード",
-    myIntraId: "イントラアイディー",
-    myHouse: "ハウス",
-    modifyButton: "修正",
-    win: "勝",
-    lose: "敗",
-    modifyMyInfoTitle: "ユーザー情報修正",
-    modifyMyInfoImageButton: "アップロード"
-  },
-  house: {
-    griffindor: "グリフィンドール",
-    hufflepuff: "ハッフルパフ",
-    ravenclaw: "レイブンクロー",
-    slytherin: "スリザリン"
-  }
+	navBar: {
+		brand: "テイル パッセンジャー",
+		pongGame: "ポンゲーム",
+		rank: "ランク",
+		records: "記録",
+		profile: "プロフィール",
+		settings: "設定",
+		logout: "ログアウト",
+		language: "言語",
+		english: "英語",
+		korean: "韓国語",
+		japanese: "日本語"
+	},
+	selectMode: {
+		mainText: "ゲームモードを選択",
+		singleMode: "シングルモード",
+		singleModeDesc: "コンピューターと対戦するシングルモード",
+		multiMode: "マルチモード",
+		multiModeDesc: "他のユーザーと対戦するマルチモード",
+		tornamentMode: "トーナメントモード",
+		tornamentModeDesc: "4人で対戦するトーナメントモード"
+	},
+	tornament: {
+		mainText: "トーナメント表",
+		mainTextDesc: "トーナメントを作ることも、参加することもできる。",
+		list: "トーナメント名",
+		createBtn: "新しいトーナメントを作る",
+		refresh: "リフレッシュ"
+	},
+	rank: {
+		mainText: "トッププレイヤー",
+		subText: "プレイしていただきありがとうございます",
+		thRank: "ランク",
+		thUserProfile: "フロフィルイメージ",
+		thUserIntraId: "イントラアイディー",
+		thUserName: "ユーザー名",
+		thWins: "勝利",
+		thLoses: "敗北",
+		thRankPoint: "ランクポイント",
+		thFriendRequestBtn: "フレンド申請",
+		tootipRequest: "申請"
+	},
+	records: {
+		mainText: "レコード",
+	},
+	profileTab: {
+		myInfoTab: "マイインフォ",
+		friendListTab: "フレンドリスト",
+	},
+	friendList: {
+		nofriends: "フレンドがいません",
+		friendsNumber: "ナンバー",
+		friendsProfile: "フロフィルイメージ",
+		friendsNickname: "ニックネーム",
+		friendsConnection: "コネクション",
+		friendsRequest: "フレンド申請",
+		tooltipAccept: "承認",
+		tooltipRefuse: "拒否"
+	},
+	myInfo: {
+		myNickname: "ニックネーム",
+		myRecord: "レコード",
+		myIntraId: "イントラアイディー",
+		myHouse: "ハウス",
+		modifyButton: "修正",
+		win: "勝",
+		lose: "敗",
+		modifyMyInfoTitle: "ユーザー情報修正",
+		modifyMyInfoImageButton: "アップロード"
+	},
+	house: {
+		griffindor: "グリフィンドール",
+		hufflepuff: "ハッフルパフ",
+		ravenclaw: "レイブンクロー",
+		slytherin: "スリザリン"
+	}
 };
 
 export default jaLocale;

--- a/frontend/src/utils/locales/ko.js
+++ b/frontend/src/utils/locales/ko.js
@@ -1,71 +1,80 @@
 const koLocale = {
-  navBar: {
-    brand: "테일 패신저",
-    pongGame: "퐁 게임",
-    rank: "랭킹",
-    records: "기록",
-    profile: "프로필",
-    settings: "설정",
-    logout: "로그아웃",
-    language: "언어",
-    english: "English",
-    korean: "한국어",
-    japanese: "일본어"
-  },
-  selectMode: {
-    mainText: "게임 모드를 선택하세요",
-    singleMode: "싱글 모드",
-    singleModeDesc: "컴퓨터와 대결하는 싱글 모드",
-    multiMode: "멀티 모드",
-    multiModeDesc: "다른 유저와 대결하는 멀티 모드"
-  },
-  rank: {
-    mainText: "최고 플레이어",
-    subText: "플레이해 주셔서 감사합니다",
-    thRank: "순위",
-    thUserProfile: "프로필 사진",
-    thUserIntraId: "인트라 아이디",
-    thUserName: "사용자 이름",
-    thWins: "승리",
-    thLoses: "패배",
-    thRankPoint: "랭크 포인트",
-    thFriendRequestBtn: "친구 신청",
-    tootipRequest: "신청"
-  },
-  records: {
-    mainText: "기록",
-  },
-  profileTab: {
-    myInfoTab: "내 정보",
-    friendListTab: "친구목록",
-  },
-  friendList: {
-    nofriends: "친구가 없습니다",
-    friendsNumber: "번호",
-    friendsProfile: "프로필 사진",
-    friendsNickname: "닉네임",
-    friendsConnection: "접속 상태",
-    friendsRequest: "친구 신청",
-    tooltipAccept: "수락",
-    tooltipRefuse: "거절"
-  },
-  myInfo: {
-    myNickname: "닉네임",
-    myRecord: "기록",
-    myIntraId: "인트라 아이디",
-    myHouse: "기숙사",
-    modifyButton: "수정",
-    win: "승",
-    lose: "패",
-    modifyMyInfoTitle: "회원 정보 수정",
-    modifyMyInfoImageButton: "업로드"
-  },
-  house: {
-    griffindor: "그리핀도르",
-    hufflepuff: "후플푸프",
-    ravenclaw: "래번클로",
-    slytherin: "슬리데린"
-  }
+	navBar: {
+		brand: "테일 패신저",
+		pongGame: "퐁 게임",
+		rank: "랭킹",
+		records: "기록",
+		profile: "프로필",
+		settings: "설정",
+		logout: "로그아웃",
+		language: "언어",
+		english: "English",
+		korean: "한국어",
+		japanese: "일본어"
+	},
+	selectMode: {
+		mainText: "게임 모드를 선택하세요",
+		singleMode: "싱글 모드",
+		singleModeDesc: "컴퓨터와 대결하는 싱글 모드",
+		multiMode: "멀티 모드",
+		multiModeDesc: "다른 유저와 대결하는 멀티 모드",
+		tornamentMode: "토너먼트 모드",
+		tornamentModeDesc: "4명과 대결하는 토너먼트 모드"
+	},
+	tornament: {
+		mainText: "토너먼트 목록",
+		mainTextDesc: "새 토너먼트를 생성하거나 참가할 수 있습니다.",
+		list: "토너먼트 이름",
+		createBtn: "새 토너먼트 만들기",
+		refresh: "새로고침"
+	},
+	rank: {
+		mainText: "최고 플레이어",
+		subText: "플레이해 주셔서 감사합니다",
+		thRank: "순위",
+		thUserProfile: "프로필 사진",
+		thUserIntraId: "인트라 아이디",
+		thUserName: "사용자 이름",
+		thWins: "승리",
+		thLoses: "패배",
+		thRankPoint: "랭크 포인트",
+		thFriendRequestBtn: "친구 신청",
+		tootipRequest: "신청"
+	},
+	records: {
+		mainText: "기록",
+	},
+	profileTab: {
+		myInfoTab: "내 정보",
+		friendListTab: "친구목록",
+	},
+	friendList: {
+		nofriends: "친구가 없습니다",
+		friendsNumber: "번호",
+		friendsProfile: "프로필 사진",
+		friendsNickname: "닉네임",
+		friendsConnection: "접속 상태",
+		friendsRequest: "친구 신청",
+		tooltipAccept: "수락",
+		tooltipRefuse: "거절"
+	},
+	myInfo: {
+		myNickname: "닉네임",
+		myRecord: "기록",
+		myIntraId: "인트라 아이디",
+		myHouse: "기숙사",
+		modifyButton: "수정",
+		win: "승",
+		lose: "패",
+		modifyMyInfoTitle: "회원 정보 수정",
+		modifyMyInfoImageButton: "업로드"
+	},
+	house: {
+		griffindor: "그리핀도르",
+		hufflepuff: "후플푸프",
+		ravenclaw: "래번클로",
+		slytherin: "슬리데린"
+	}
 };
 
 export default koLocale;

--- a/frontend/src/utils/routeInfo.js
+++ b/frontend/src/utils/routeInfo.js
@@ -7,15 +7,17 @@ import Profile from "../pages/profile.js";
 import AboutUs from "../pages/aboutus.js";
 import SocketTest from "../pages/example_websocket.js";
 import RecordsSearch from "../pages/recordsSearch.js";
+import Tornament from "../pages/tornament.js";
 
 export const routes = [
-    { path: /^\/$/, element: Home },
-    { path: /^\/game$/, element: Game },
-    { path: /^\/rank$/, element: Rank },
-    { path: /^\/records$/, element: RecordsSearch },
-    { path: /^\/aboutus$/, element: AboutUs },
-    { path: /^\/selectmode$/, element: SelectMode },
-    { path: /^\/profile$/, element: Profile },
-    { path: /^\/sockettest$/, element: SocketTest },
-    { path: /.*/, element: NotFound },
+	{ path: /^\/$/, element: Home },
+	{ path: /^\/game$/, element: Game },
+	{ path: /^\/rank$/, element: Rank },
+	{ path: /^\/records$/, element: RecordsSearch },
+	{ path: /^\/aboutus$/, element: AboutUs },
+	{ path: /^\/selectmode$/, element: SelectMode },
+	{ path: /^\/profile$/, element: Profile },
+	{ path: /^\/general_game\/(.+)$/, element: SocketTest },
+	{ path: /^\/tornament$/, element: Tornament },
+	{ path: /.*/, element: NotFound },
 ];

--- a/middleware/conf/default.conf
+++ b/middleware/conf/default.conf
@@ -32,5 +32,16 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+		  location /ws/ {
+        proxy_pass http://web:443;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }
 


### PR DESCRIPTION
### Summary
- 토너먼트 모드 버튼, 페이지 초안 추가

### Description
- 토너먼트페이지에서 생성된 토너먼트 방을 확인하고 생성, 참가 까지만 가능합니다.

### To Do
- 참가 이후의 진행은 아직 구현되지 않았습니다 ( 인원 확인, 라운드 순차진행)
- 언어가 내부적인 innerHTML을 수정하는 부분은 다른 방법으로 해야 할 것 같아서 구현과 함께 진행하겠습니다